### PR TITLE
Use gdate in macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,12 @@
 SHA := $(shell git rev-parse --short=8 HEAD)
 GITVERSION := $(shell git describe --long --always)
-BUILDDATE := $(shell date --rfc-3339=seconds)
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Linux)
+	BUILDDATE := $(shell date --rfc-3339=seconds)
+endif
+ifeq ($(UNAME_S),Darwin)
+	BUILDDATE := $(shell gdate --rfc-3339=seconds)
+endif
 
 all: test
 	go build -ldflags "-X 'main.revision=$(GITVERSION)' -X 'main.builddate=$(BUILDDATE)'" -buildmode=c-shared -o out_redis.so .


### PR DESCRIPTION
Because macOS system provides BSD date instead of GNU date.

Otherwise, I get the following error:

```log
date: illegal option -- -
usage: date [-jnRu] [-d dst] [-r seconds] [-t west] [-v[+|-]val[ymwdHMS]] ... 
            [-f fmt date | [[[mm]dd]HH]MM[[cc]yy][.ss]] [+format]
go test -cover -race -coverprofile=coverage.txt -covermode=atomic
PASS
coverage: 43.4% of statements
ok  	_/Users/cosmo/GitHub/fluent-bit-go-redis-output	1.053s
go build -ldflags "-X 'main.revision=e3efa4a' -X 'main.builddate='" -buildmode=c-shared -o out_redis.so .
```